### PR TITLE
SST datasets added 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [Unreleased]
+### New Datasets
+- Added dataset seasurface temperature anomalies (SSTA) datasets [#1](https://github.com/ISSI-CONSTRAIN/catalog/pull/1)
+
+### Updated Datasets
+
+### Removed Datasets
+
+### Bug Fixes
+
+### Internal Changes

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ ds2 = cat['ISCCP']['ISCCP_BASIC_HGM'].to_dask()
 ds3 = cat['MPI_TCO']['BCO']['surfacemet_wxt_v1'].to_dask()
 ds4 = cat['morphologies']['SGFF'].to_dask()
 ds5 = cat['CCF']['ERA5_CCF'].to_dask()
+ds6 = cat['SSTA']['traj'].to_dask()
 ```

--- a/SSTA.yaml
+++ b/SSTA.yaml
@@ -1,0 +1,21 @@
+description: "ISSI SSTA catalog"
+
+sources:
+  objs:
+    driver: zarr
+    description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
+    args:
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
+      consolidated: true
+  trajs:
+    driver: zarr
+    description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
+    args:
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      consolidated: true
+  maps:
+    driver: zarr
+    description: daily SST maps in the North Atlantic
+    args:
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
+      consolidated: true

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,13 +36,13 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
       consolidated: false
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
       consolidated: false
   SSTA_maps:
     driver: zarr

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,12 +36,12 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
-      consolidated: false
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
+      #consolidated: false
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      consolidated: false
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      #consolidated: false
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -37,11 +37,11 @@ sources:
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
       urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
-      consolidated: true
+      consolidated: false
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
       urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      consolidated: true
+      consolidated: false
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -37,11 +37,17 @@ sources:
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
       urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
-      #consolidated: false
+      consolidated: none
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
       urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      #consolidated: false
+      consolidated: none
+  sample_wsat:
+    driver: zarr
+    description: Sample of Windsat data
+    args:
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/sample_wsat/windsat.zarr
+      consolidated: true
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -37,19 +37,19 @@ sources:
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
       urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
-      consolidated: false
+      consolidated: true
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
       urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      consolidated: false
+      consolidated: true
   SSTA_maps:
     driver: zarr
     description: daily SST maps in the North Atlantic
     args:
       urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
-      consolidated: false
+      consolidated: true
   sample_wsat:
     driver: zarr
     description: Sample of Windsat data

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,12 +36,12 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
+      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
       consolidated: true
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
       consolidated: true
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -32,23 +32,9 @@ sources:
       path: https://raw.githubusercontent.com/ISSI-CONSTRAIN/meso-morphs/main/catalog/catalog.yaml
     driver: yaml_file_cat
     metadata: {}
-  SSTA_objs:
-    driver: zarr
-    description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
+  SSTA:
+    description: SSTA datasets
     args:
-      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
-      consolidated: true
-  SSTA_trajs:
-    driver: zarr
-    description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
-    args:
-      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      consolidated: true
-  SSTA_maps:
-    driver: zarr
-    description: daily SST maps in the North Atlantic
-    args:
-      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
-      consolidated: true
-  
-    
+      path: SSTA.yaml
+    driver: yaml_file_cat
+    metadata: {}

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -32,11 +32,16 @@ sources:
       path: https://raw.githubusercontent.com/ISSI-CONSTRAIN/meso-morphs/main/catalog/catalog.yaml
     driver: yaml_file_cat
     metadata: {}
-  SSTanoms:
+  SSTA_objs:
     driver: zarr
-    description: Mesoscale daily SST anomalies in the North Atlantic
+    description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/
-      # path: https://raw.githubusercontent.com/xychen-ocn/ISSI_data_catalog/refs/heads/main/catalog.yaml
+      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
       consolidated: true
-    metadata: {}
+  SSTA_trajs:
+    driver: zarr
+    description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
+    args:
+      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      consolidated: true
+    

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -32,3 +32,10 @@ sources:
       path: https://raw.githubusercontent.com/ISSI-CONSTRAIN/meso-morphs/main/catalog/catalog.yaml
     driver: yaml_file_cat
     metadata: {}
+  SSTanoms:
+    driver: zarr
+    description: Mesoscale daily SST anomalies in the North Atlantic
+    args:
+      path: https://raw.githubusercontent.com/ISSI-CONSTRAIN/meso-morphs/main/catalog/catalog.yaml
+      consolidated: true
+    metadata: {}

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,19 +36,19 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
       consolidated: false
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
       consolidated: false
   SSTA_maps:
     driver: zarr
     description: daily SST maps in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
+      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
       consolidated: false
   sample_wsat:
     driver: zarr

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,12 +36,12 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_Objects.zarr
       consolidated: true
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
       consolidated: true
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -50,10 +50,5 @@ sources:
     args:
       urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
       consolidated: true
-  sample_wsat:
-    driver: zarr
-    description: Sample of Windsat data
-    args:
-      urlpath: https://swift.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/sample_wsat/windsat.zarr
-      consolidated: true
+  
     

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,14 +36,14 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomaly objects in the North Atlantic from GOES-POES Blended analysis
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
-      consolidated: none
+      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Objects.zarr
+      consolidated: false
   SSTA_trajs:
     driver: zarr
     description: 24-hr lagrangian trajectories initiated over SST anomaly objects in the North Atlantic
     args:
-      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
-      consolidated: none
+      urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
+      consolidated: false
   sample_wsat:
     driver: zarr
     description: Sample of Windsat data

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -36,6 +36,7 @@ sources:
     driver: zarr
     description: Mesoscale daily SST anomalies in the North Atlantic
     args:
-      path: https://raw.githubusercontent.com/ISSI-CONSTRAIN/meso-morphs/main/catalog/catalog.yaml
+      path: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTA_related/
+      # path: https://raw.githubusercontent.com/xychen-ocn/ISSI_data_catalog/refs/heads/main/catalog.yaml
       consolidated: true
     metadata: {}

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -44,6 +44,12 @@ sources:
     args:
       urlpath: https://swiftbrowser.dkrz.de/v1/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_24hrTrajs.zarr
       consolidated: false
+  SSTA_maps:
+    driver: zarr
+    description: daily SST maps in the North Atlantic
+    args:
+      urlpath: https://swiftbrowser.dkrz.de/public/dkrz_a88749b4-3884-49bb-8c65-76571c660914/SSTAs/2018-2021_GPBLEND_SSTA_Maps.zarr
+      consolidated: false
   sample_wsat:
     driver: zarr
     description: Sample of Windsat data


### PR DESCRIPTION
Hi Hauke, 

I added 3 relevant SST datasets into the catalog (took me 13 trials to make things work..). 
Right now, it reads from the catalog like: 
```python
ds_maps = cat['SSTA_maps'].to_dask()
ds_traj = cat['SSTA_trajs'].to_dask()
ds_SSTAs = cat['SSTA_objs'].to_dask()
```
I wonder if I could improve the SSTA catalog to look more like this example you have for `cat['morphologies']['MCC']`. So I am thinking `list(cat['SSTAs'])` will give `['maps', 'objects', 'trajs']` -- what should I do to achieve this?

Thanks!
Xuanyu